### PR TITLE
Add Whisper-based audio transcription utility

### DIFF
--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from typing import Dict, Any
+
+import whisper
+
+_model = whisper.load_model("base")
+
+def transcribe_audio(audio_path: Path) -> Dict[str, Any]:
+    """Transcribe an audio file using a Whisper model.
+
+    Parameters
+    ----------
+    audio_path: Path
+        Path to the audio file to transcribe.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary containing transcription text, segments and language.
+    """
+    result = _model.transcribe(str(audio_path))
+    return {
+        "text": result.get("text", ""),
+        "segments": result.get("segments", []),
+        "language": result.get("language")
+    }


### PR DESCRIPTION
## Summary
- add a `transcribe_audio` function that loads a Whisper base model and returns transcription details

## Testing
- `python -m pytest`
- `python -m py_compile src/transcriber.py`


------
https://chatgpt.com/codex/tasks/task_e_68c52c87f17c8320aa3435f215837721