### PR TITLE
Add CLI and FastAPI API for video transcription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+downloads/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# VideoTranscriber-
+# VideoTranscriber
+
+Utilities to download videos and produce transcripts.
+
+## Usage
+
+### CLI
+
+```bash
+python src/cli.py <URL>
+```
+
+### HTTP API
+
+```bash
+uvicorn src.api:app --reload
+```
+
+Then send a POST request:
+
+```bash
+curl -X POST http://localhost:8000/transcribe -H 'Content-Type: application/json' -d '{"url": "https://example.com/video"}'
+```

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for video downloading and transcription."""

--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,18 @@
+"""FastAPI application exposing a transcription endpoint."""
+from fastapi import FastAPI
+from pydantic import BaseModel
+from downloader import download_video
+from transcriber import transcribe
+
+app = FastAPI()
+
+
+class TranscribeRequest(BaseModel):
+    url: str
+
+
+@app.post("/transcribe")
+async def transcribe_endpoint(req: TranscribeRequest) -> dict:
+    video_path = download_video(req.url)
+    transcript = transcribe(video_path)
+    return {"text": transcript}

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,18 @@
+"""Command line interface for video transcription."""
+from argparse import ArgumentParser
+from downloader import download_video
+from transcriber import transcribe
+
+
+def main() -> None:
+    parser = ArgumentParser(description="Download and transcribe a video from a URL")
+    parser.add_argument("url", help="URL of the video to transcribe")
+    args = parser.parse_args()
+
+    video_path = download_video(args.url)
+    transcript = transcribe(video_path)
+    print(transcript)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/downloader.py
+++ b/src/downloader.py
@@ -1,0 +1,22 @@
+"""Simple video downloader placeholder."""
+from pathlib import Path
+
+
+def download_video(url: str) -> str:
+    """Pretend to download a video and return the path to a file.
+
+    Parameters
+    ----------
+    url: str
+        URL of the video to download.
+
+    Returns
+    -------
+    str
+        Path to the downloaded file.
+    """
+    downloads_dir = Path("downloads")
+    downloads_dir.mkdir(exist_ok=True)
+    file_path = downloads_dir / "video.txt"
+    file_path.write_text(f"Downloaded from {url}\n")
+    return str(file_path)

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -1,0 +1,10 @@
+"""Simple transcriber placeholder."""
+from pathlib import Path
+
+
+def transcribe(audio_path: str) -> str:
+    """Return dummy transcription for the provided audio path."""
+    path = Path(audio_path)
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {audio_path}")
+    return f"Transcribed {path.name}"


### PR DESCRIPTION
## Summary
- add placeholder downloader and transcriber modules
- add CLI for downloading and transcribing from URL
- provide optional FastAPI API with POST /transcribe endpoint
- document usage examples

## Testing
- `python -m pytest`
- `pip install fastapi uvicorn` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68c52c8ccac883208e80a023e56bddc7